### PR TITLE
feat(parser): 2.1 Define whitespace and comment rules

### DIFF
--- a/.kiro/specs/parser-pest-rewrite/tasks.md
+++ b/.kiro/specs/parser-pest-rewrite/tasks.md
@@ -14,7 +14,7 @@ This implementation plan breaks down the rust-peg parser rewrite into discrete, 
   - _Requirements: 1.1, 9.5_
 
 - [ ] 2. Define core grammar structure with whitespace and comments
-  - [ ] 2.1 Define whitespace and comment rules
+  - [x] 2.1 Define whitespace and comment rules
     - Implement _ rule for optional whitespace (quiet!)
     - Implement __ rule for required whitespace
     - Implement line_comment rule for // comments

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5140,4 +5140,51 @@ mod peg_tests {
         let result = crusty_peg_parser::test_int("/* block comment */ 42");
         assert_eq!(result, Ok(42));
     }
+
+    #[test]
+    fn test_peg_mixed_whitespace_and_comments() {
+        // Test mixed whitespace and comments
+        let result = crusty_peg_parser::test_int("  /* comment */  42  // trailing\n");
+        assert_eq!(result, Ok(42));
+
+        let result = crusty_peg_parser::test_int("\t\n  // comment\n  /* block */  \n  42  \n");
+        assert_eq!(result, Ok(42));
+    }
+
+    #[test]
+    fn test_peg_nested_block_comments_not_supported() {
+        // Nested block comments are not supported in C-style comments
+        // This should parse the first /* */ and then fail on the remaining text
+        let result = crusty_peg_parser::test_int("/* outer /* inner */ */ 42");
+        // This will fail because after the first */ the parser sees */ 42 which is invalid
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_peg_line_comment_without_newline() {
+        // Line comments at end of input (no trailing newline)
+        let result = crusty_peg_parser::test_int("42 // comment");
+        assert_eq!(result, Ok(42));
+    }
+
+    #[test]
+    fn test_peg_multiple_line_comments() {
+        // Multiple line comments
+        let result = crusty_peg_parser::test_int("// first\n// second\n42");
+        assert_eq!(result, Ok(42));
+    }
+
+    #[test]
+    fn test_peg_block_comment_multiline() {
+        // Block comment spanning multiple lines
+        let result = crusty_peg_parser::test_int("/* line 1\n   line 2\n   line 3 */ 42");
+        assert_eq!(result, Ok(42));
+    }
+
+    #[test]
+    fn test_peg_whitespace_types() {
+        // Test different whitespace types: space, tab, newline, carriage return
+        let result = crusty_peg_parser::test_int(" \t\r\n42\n\r\t ");
+        assert_eq!(result, Ok(42));
+    }
 }


### PR DESCRIPTION
## Task Reference

Task 2.1 from 

## Summary

This task implements whitespace and comment rules for the rust-peg parser rewrite. The core implementation was already completed in task 1, so this task focused on adding comprehensive test coverage for edge cases.

## Changes

### Implementation
- Whitespace rules (`_` for optional, `__` for required) using `quiet``` macro
- Line comment rule for `//` style comments
- Block comment rule for `/* */` style comments

### Tests
Added 6 comprehensive test cases covering:
- Mixed whitespace and comments
- Nested block comments (correctly not supported)
- Line comments without trailing newline
- Multiple consecutive line comments
- Multiline block comments
- All whitespace types (space, tab, CR, LF)

### Quality
- All 898 tests pass
- Clippy checks pass with no warnings
- Code formatting verified
- Pre-commit hooks pass

## Requirements Validated

- Requirement 1.5: Whitespace and comment handling