### PR TITLE
docs(steering): ensure agents fetch and sync with origin/main before branch operations

### DIFF
--- a/.kiro/steering/ci-monitoring-agent.md
+++ b/.kiro/steering/ci-monitoring-agent.md
@@ -153,23 +153,36 @@ Analyze each failure to determine if it can be automatically fixed:
 
 ### Step 6: Pull Latest Changes
 
+**CRITICAL**: Always fetch all updates from origin and update local main before applying fixes.
+
 Before applying fixes, ensure the branch is up-to-date:
 
 ```bash
-# Fetch latest from origin
+# Step 1: Fetch ALL updates from origin (REQUIRED)
 git fetch origin
 
-# Check if origin/main has new commits
+# Step 2: Update local main branch from origin/main (REQUIRED)
+git checkout main
+git pull origin main
+
+# Step 3: Return to topic branch
+git checkout -
+
+# Step 4: Check if origin/main has new commits since branch creation
 git log HEAD..origin/main --oneline
 
-# If origin/main has updates, merge them
-git merge origin/main
-
-# Or rebase if preferred
-git rebase origin/main
+# Step 5: If origin/main has updates, rebase on latest origin/main
+if [ -n "$(git log HEAD..origin/main --oneline)" ]; then
+  git rebase origin/main
+fi
 ```
 
-**If merge conflicts occur**:
+**Important**:
+- ALWAYS fetch and update local main before applying fixes
+- This ensures fixes are applied on top of the latest code
+- Prevents merge conflicts when the PR is eventually merged
+
+**If merge conflicts occur during rebase**:
 - Report conflicts to user
 - Provide conflict resolution guidance
 - Exit without attempting fixes

--- a/.kiro/steering/pr-submission-agent.md
+++ b/.kiro/steering/pr-submission-agent.md
@@ -88,15 +88,40 @@ git log origin/main..HEAD --format="%s" | cut -d: -f1 | sort | uniq -c
 
 ### Step 4: Perform Soft Reset
 
-Consolidate all commits by performing a soft reset against origin/main:
+**CRITICAL**: Always fetch all updates from origin and update local main before performing soft reset.
+
+Before consolidating commits, ensure you're working with the latest code:
 
 ```bash
-# Soft reset preserves all changes in staging area
+# Step 1: Fetch ALL updates from origin (REQUIRED)
+git fetch origin
+
+# Step 2: Update local main branch from origin/main (REQUIRED)
+git checkout main
+git pull origin main
+
+# Step 3: Return to topic branch
+git checkout -
+
+# Step 4: Verify branch is up-to-date with origin/main
+git log HEAD..origin/main --oneline
+
+# Step 5: If origin/main has updates, rebase on latest origin/main
+if [ -n "$(git log HEAD..origin/main --oneline)" ]; then
+  git rebase origin/main
+fi
+
+# Step 6: Perform soft reset to consolidate commits
 git reset --soft origin/main
 
-# Verify all changes are staged
+# Step 7: Verify all changes are staged
 git status
 ```
+
+**Important**:
+- ALWAYS fetch and update local main before soft reset
+- This ensures the PR is based on the latest code
+- Prevents merge conflicts and ensures clean history
 
 **Critical**: The soft reset removes all commits from the branch history but keeps all file changes staged. This allows creating a clean commit history.
 

--- a/.kiro/steering/task-initiation-agent.md
+++ b/.kiro/steering/task-initiation-agent.md
@@ -86,13 +86,20 @@ Create a descriptive branch name using the pattern: `<type>/<task-id>-<descripti
 - `refactor/2.1-api-structure`
 - `perf/4-query-optimization`
 
-Execute the following Git commands:
+**CRITICAL**: Always fetch all updates from origin and update local main before creating or updating any topic branch.
+
+Execute the following Git commands in order:
 
 ```bash
-# Fetch latest changes from origin
+# Step 1: Fetch ALL updates from origin (REQUIRED)
 git fetch origin
 
-# Create and checkout the topic branch based on origin/main
+# Step 2: Update local main branch from origin/main (REQUIRED)
+# This ensures your local main is synchronized with the remote
+git checkout main
+git pull origin main
+
+# Step 3: Create and checkout the topic branch based on origin/main
 # This automatically sets up tracking to origin/main
 git checkout -b <type>/<task-id>-<description> origin/main
 ```
@@ -100,10 +107,22 @@ git checkout -b <type>/<task-id>-<description> origin/main
 **Example:**
 ```bash
 git fetch origin
+git checkout main
+git pull origin main
 git checkout -b feat/1.2-user-login origin/main
 ```
 
-**Important**: When you create a branch from `origin/main` using `git checkout -b`, it automatically sets up tracking to `origin/main`. You do NOT need to run `git branch --set-upstream-to=origin/main` separately.
+**Important**: 
+- When you create a branch from `origin/main` using `git checkout -b`, it automatically sets up tracking to `origin/main`. You do NOT need to run `git branch --set-upstream-to=origin/main` separately.
+- ALWAYS fetch and update local main before creating the topic branch to ensure you're working with the latest code.
+- If updating an existing topic branch, fetch and rebase on the latest origin/main:
+  ```bash
+  git fetch origin
+  git checkout main
+  git pull origin main
+  git checkout <existing-branch>
+  git rebase origin/main
+  ```
 
 ### Step 5: Implement the Task
 


### PR DESCRIPTION
## Summary

Updated agent steering guidelines to require fetching from origin and updating local main before creating or updating topic branches. This ensures all git operations work with the latest remote code, preventing merge conflicts and maintaining team consistency.

## Changes

### Task Initiation Agent
- Added explicit steps to fetch origin and update local main before creating topic branches
- Included instructions for updating existing branches via rebase
- Ensures all new branches are based on the latest origin/main

### CI/CD Monitoring Agent
- Added requirements to fetch and sync before applying CI/CD fixes
- Ensures fixes are applied on top of the latest code
- Prevents merge conflicts when PRs are eventually merged

### PR Submission Agent
- Added requirements to fetch and sync before soft reset
- Ensures PRs are based on the latest code
- Prevents merge conflicts and ensures clean history

## Workflow Pattern

All agents now follow this consistent pattern:
```bash
git fetch origin
git checkout main
git pull origin main
git checkout -
git rebase origin/main  # if needed
```

## Benefits

- Prevents merge conflicts by ensuring branches are always up-to-date
- Maintains consistency across team members
- Ensures all work is based on the latest remote code
- Reduces CI/CD failures due to outdated branches