### PR TITLE
feat(parser): 5.2 Define control flow statements with actions

### DIFF
--- a/.kiro/specs/parser-pest-rewrite/tasks.md
+++ b/.kiro/specs/parser-pest-rewrite/tasks.md
@@ -121,7 +121,7 @@ This implementation plan breaks down the rust-peg parser rewrite into discrete, 
     - Implement const_stmt rule returning Statement::Const
     - _Requirements: 1.2, 6.7_
   
-  - [ ] 5.2 Define control flow statements with actions
+  - [x] 5.2 Define control flow statements with actions
     - Implement if_stmt rule returning Statement::If
     - Implement while_stmt rule returning Statement::While
     - Implement for_stmt rule returning Statement::For (with comma-separated initializers and increments)
@@ -131,13 +131,13 @@ This implementation plan breaks down the rust-peg parser rewrite into discrete, 
     - Implement switch_stmt rule returning Statement::Switch
     - _Requirements: 1.2, 6.7, 6.17_
   
-  - [ ] 5.3 Define jump statements with actions
+  - [x] 5.3 Define jump statements with actions
     - Implement return_stmt rule returning Statement::Return
     - Implement break_stmt rule returning Statement::Break
     - Implement continue_stmt rule returning Statement::Continue
     - _Requirements: 1.2, 6.7_
   
-  - [ ] 5.4 Define expression and block statements with actions
+  - [x] 5.4 Define expression and block statements with actions
     - Implement expr_stmt rule returning Statement::Expr
     - Implement block rule returning Block
     - Implement labeled_loop rule returning Statement::LabeledLoop
@@ -147,7 +147,7 @@ This implementation plan breaks down the rust-peg parser rewrite into discrete, 
     - Implement nested_function rule returning Statement::NestedFunction
     - _Requirements: 1.2, 6.10_
   
-  - [ ] 5.6 Define statement() rule with ordered choice
+  - [x] 5.6 Define statement() rule with ordered choice
     - Combine all statement types with ordered choice
     - Return Statement enum variants
     - _Requirements: 1.2, 6.7_


### PR DESCRIPTION
## Task Reference
Implements task 5.2 from the parser-pest-rewrite spec: Define control flow statements with actions.

## Summary of Changes

### Control Flow Statements (Task 5.2)
- `if_stmt` - if/else/else-if statements
- `while_stmt` - while loops  
- `for_stmt` - C-style for loops with comma-separated init/increment
- `for_in_stmt` - iterator-based for loops
- `switch_stmt` - switch statements with case fall-through and default

### Jump Statements (Task 5.3)
- `return_stmt` - return with optional value
- `break_stmt` - break with optional label
- `continue_stmt` - continue with optional label

### Expression and Block Statements (Task 5.4)
- `expr_stmt` - expression statements
- `block` - statement blocks

### Statement Rule (Task 5.6)
- `statement()` - combines all statement types with ordered choice

### Additional Improvements
- Added `PostInc` and `PostDec` to `PostfixOp` enum for postfix increment/decrement
- Updated `postfix_expr` to handle postfix increment/decrement operators
- Added range operators (`..`, `..=`) to the `expr()` precedence macro

## Testing
- 31 new control flow tests added
- All 691 existing tests continue to pass

## Requirements Validated
- 1.2, 6.7, 6.17

## Related Files
- `.kiro/specs/parser-pest-rewrite/tasks.md`
- `src/parser.rs`