### PR TITLE
feat(parser): 6.6-6.8 Complete item grammar with macro_def, item(), and file() rules

### DIFF
--- a/.kiro/specs/parser-pest-rewrite/tasks.md
+++ b/.kiro/specs/parser-pest-rewrite/tasks.md
@@ -152,7 +152,7 @@ This implementation plan breaks down the rust-peg parser rewrite into discrete, 
     - Return Statement enum variants
     - _Requirements: 1.2, 6.7_
 
-- [ ] 6. Define item (top-level declaration) grammar with actions
+- [x] 6. Define item (top-level declaration) grammar with actions
   - [x] 6.1 Define attribute rule with actions
     - Implement attribute rule returning Attribute
     - Support attribute arguments (ident, literal, name=value)
@@ -189,13 +189,13 @@ This implementation plan breaks down the rust-peg parser rewrite into discrete, 
     - Support macro body as token sequence
     - _Requirements: 1.2, 6.6_
   
-  - [ ] 6.7 Define item() rule with ordered choice
+  - [x] 6.7 Define item() rule with ordered choice
     - Combine all item types with ordered choice
     - Handle attributes on items
     - Return Item enum variants
     - _Requirements: 1.2_
   
-  - [ ] 6.8 Define file rule with actions
+  - [x] 6.8 Define file rule with actions
     - Implement file rule returning File
     - Parse multiple items
     - Handle empty files


### PR DESCRIPTION
## Summary

Completes Task 6 of the PEG parser rewrite by implementing the remaining item-level grammar rules.

## Changes

### Task 6.6: Macro Definition Rule
- Implemented `macro_def()` rule returning `Item::MacroDefinition`
- Only parentheses delimiter supported for `#define` declarations (per language spec)
- Added 11 comprehensive tests for macro definitions

### Task 6.7: Item Rule
- Added `item()` rule combining all item types with ordered choice
- Order: macro_def → struct_def → enum_def → typedef_def → function
- Added 10 tests covering all item types

### Task 6.8: File Rule
- Added `file()` rule for parsing complete source files
- Handles empty files, single items, and complex multi-item files
- Added 8 tests for file parsing

### Bug Fix
- Added `&self` parameter support in `function_param` rule to match old parser behavior

## Testing

- All 784 tests pass
- Formatting check passes (`cargo fmt`)
- Linting check passes (`cargo clippy`)

## Task References

- `.kiro/specs/parser-pest-rewrite/tasks.md` - Tasks 6.6, 6.7, 6.8